### PR TITLE
任意のユーザーの投稿を取得する

### DIFF
--- a/app/profile/[userId]/_hooks/useUserPosts.tsx
+++ b/app/profile/[userId]/_hooks/useUserPosts.tsx
@@ -28,7 +28,7 @@ export const useUserPosts = (userId: number) => {
     // TODO: postsがnullの時だけにしてみる
     if (posts === null) getUserPosts(userId);
     // TODO: 依存配列消してみる
-  }, [posts]);
+  }, []);
 
   return { posts, error };
 };

--- a/app/profile/[userId]/_hooks/useUserPosts.tsx
+++ b/app/profile/[userId]/_hooks/useUserPosts.tsx
@@ -8,8 +8,6 @@ export const useUserPosts = (userId: number) => {
 
   useEffect(() => {
     const getUserPosts = async (userId: number) => {
-      if (!userId) return;
-
       try {
         const res = await apiClient.get(`posts/get/${userId}`);
         setPosts(res.data);

--- a/app/profile/[userId]/_hooks/useUserPosts.tsx
+++ b/app/profile/[userId]/_hooks/useUserPosts.tsx
@@ -12,12 +12,6 @@ export const useUserPosts = (userId: number) => {
 
       try {
         const res = await apiClient.get(`posts/get/${userId}`);
-
-        console.log(res.data);
-        // FIXME: postsを一件も持たないユーザもいるので修正必要
-        if (res.data.length === 0)
-          throw new Error(`Posts not found, that user ID is ${userId}`);
-
         setPosts(res.data);
       } catch (error) {
         console.log(error);

--- a/app/profile/[userId]/_hooks/useUserPosts.tsx
+++ b/app/profile/[userId]/_hooks/useUserPosts.tsx
@@ -1,0 +1,31 @@
+import apiClient from '@/app/_lib/apiClient';
+import { PostType } from '@/app/types/post';
+import { useEffect, useState } from 'react';
+
+export const useUserPosts = (userId: number) => {
+  const [posts, setPosts] = useState<PostType[] | null>(null);
+  const [error, setError] = useState<unknown | null>(null);
+
+  useEffect(() => {
+    const getUserPosts = async (userId: number) => {
+      if (!userId) return;
+
+      try {
+        const res = await apiClient.get(`posts/get/${userId}`);
+
+        console.log(...res.data.posts);
+        if (!res.data.posts)
+          throw new Error(`Posts not found, that user ID is ${userId}`);
+
+        setPosts(res.data.posts);
+      } catch (error) {
+        console.log(error);
+        setError(error);
+      }
+    };
+
+    getUserPosts(userId);
+  }, [posts, error]);
+
+  return { posts, error };
+};

--- a/app/profile/[userId]/_hooks/useUserPosts.tsx
+++ b/app/profile/[userId]/_hooks/useUserPosts.tsx
@@ -2,12 +2,12 @@ import apiClient from '@/app/_lib/apiClient';
 import { PostType } from '@/app/types/post';
 import { useEffect, useState } from 'react';
 
-export const useUserPosts = (userId: number) => {
+export const useUserPosts = (userId: string) => {
   const [posts, setPosts] = useState<PostType[] | null>(null);
   const [error, setError] = useState<unknown | null>(null);
 
   useEffect(() => {
-    const getUserPosts = async (userId: number) => {
+    const getUserPosts = async (userId: string) => {
       try {
         const res = await apiClient.get(`posts/get/${userId}`);
         setPosts(res.data);

--- a/app/profile/[userId]/_hooks/useUserPosts.tsx
+++ b/app/profile/[userId]/_hooks/useUserPosts.tsx
@@ -25,9 +25,7 @@ export const useUserPosts = (userId: number) => {
       }
     };
 
-    // TODO: postsがnullの時だけにしてみる
     if (posts === null) getUserPosts(userId);
-    // TODO: 依存配列消してみる
   }, []);
 
   return { posts, error };

--- a/app/profile/[userId]/_hooks/useUserPosts.tsx
+++ b/app/profile/[userId]/_hooks/useUserPosts.tsx
@@ -13,19 +13,22 @@ export const useUserPosts = (userId: number) => {
       try {
         const res = await apiClient.get(`posts/get/${userId}`);
 
-        console.log(...res.data.posts);
-        if (!res.data.posts)
+        console.log(res.data);
+        // FIXME: postsを一件も持たないユーザもいるので修正必要
+        if (res.data.length === 0)
           throw new Error(`Posts not found, that user ID is ${userId}`);
 
-        setPosts(res.data.posts);
+        setPosts(res.data);
       } catch (error) {
         console.log(error);
         setError(error);
       }
     };
 
-    getUserPosts(userId);
-  }, [posts, error]);
+    // TODO: postsがnullの時だけにしてみる
+    if (posts === null) getUserPosts(userId);
+    // TODO: 依存配列消してみる
+  }, [posts]);
 
   return { posts, error };
 };

--- a/app/profile/[userId]/_hooks/useUserProfile.tsx
+++ b/app/profile/[userId]/_hooks/useUserProfile.tsx
@@ -22,7 +22,7 @@ export const useUserProfile = (userId: number) => {
       }
     };
 
-    getUserProfile(userId);
+    if (profile === null) getUserProfile(userId);
   }, []);
 
   return { profile, error };

--- a/app/profile/[userId]/_hooks/useUserProfile.tsx
+++ b/app/profile/[userId]/_hooks/useUserProfile.tsx
@@ -2,12 +2,12 @@ import { useEffect, useState } from 'react';
 import apiClient from '../../../_lib/apiClient';
 import { ProfileType } from '../../../types/profile';
 
-export const useUserProfile = (userId: number) => {
+export const useUserProfile = (userId: string) => {
   const [profile, setProfile] = useState<ProfileType | null>(null);
   const [error, setError] = useState<unknown | null>(null);
 
   useEffect(() => {
-    const getUserProfile = async (userId: number) => {
+    const getUserProfile = async (userId: string) => {
       if (!userId) return;
       try {
         const res = await apiClient.get(`/profile/find/${userId}`);

--- a/app/profile/[userId]/_hooks/useUserProfile.tsx
+++ b/app/profile/[userId]/_hooks/useUserProfile.tsx
@@ -23,7 +23,7 @@ export const useUserProfile = (userId: number) => {
     };
 
     getUserProfile(userId);
-  }, [profile, userId]);
+  }, []);
 
   return { profile, error };
 };

--- a/app/profile/[userId]/page.tsx
+++ b/app/profile/[userId]/page.tsx
@@ -1,12 +1,17 @@
 'use client';
 import { useUserProfile } from '@/app/profile/[userId]/_hooks/useUserProfile';
-import { notFound } from 'next/navigation';
+import { PostType } from '@/app/types/post';
+// import { notFound } from 'next/navigation';
+import { useUserPosts } from './_hooks/useUserPosts';
 
 const UserProfile = ({ params }: { params: { userId: number } }) => {
   // TODO: profileがnullの時が内容にローディングとか入れたい
-  const { profile, error } = useUserProfile(params.userId);
+  const { profile, error: gettingProfileError } = useUserProfile(params.userId);
 
-  if (error) notFound();
+  const { posts, error: gettingPostsError } = useUserPosts(params.userId);
+
+  // FIXME: 投稿が無いときどうするか
+  // if (gettingProfileError || gettingPostsError) notFound();
 
   return (
     <div className='container mx-auto px-4 py-8'>
@@ -27,19 +32,26 @@ const UserProfile = ({ params }: { params: { userId: number } }) => {
             </div>
           </div>
         </div>
-        {/* TODO: プロフィール画面に表示されているユーザーのpostだけを表示する */}
-        {/* <div className='bg-white shadow-md rounded p-4 mb-4' key={post.id}>
-          <div className='mb-4'>
-            <div className='flex items-center mb-2'>
-              <img className='w-10 h-10 rounded-full mr-2' alt='User Avatar' />
-              <div>
-                <h2 className='font-semibold text-md'>shincode</h2>
-                <p className='text-gray-500 text-sm'>2023/05/08</p>
+        {posts?.length !== 0 &&
+          posts?.map((post: PostType) => {
+            <div className='bg-white shadow-md rounded p-4 mb-4' key={post.id}>
+              <div className='mb-4'>
+                <div className='flex items-center mb-2'>
+                  <img
+                    className='w-10 h-10 rounded-full mr-2'
+                    alt='User Avatar'
+                  />
+                  <div>
+                    <h2 className='font-semibold text-md'>
+                      {post.author.name}
+                    </h2>
+                    <p className='text-gray-500 text-sm'>{post.createdAt}</p>
+                  </div>
+                </div>
+                <p className='text-gray-700'>{post.content}</p>
               </div>
-            </div>
-            <p className='text-gray-700'>はじめての投稿です。</p>
-          </div>
-        </div> */}
+            </div>;
+          })}
       </div>
     </div>
   );

--- a/app/profile/[userId]/page.tsx
+++ b/app/profile/[userId]/page.tsx
@@ -1,17 +1,16 @@
 'use client';
 import { useUserProfile } from '@/app/profile/[userId]/_hooks/useUserProfile';
 import { PostType } from '@/app/types/post';
-// import { notFound } from 'next/navigation';
+import { notFound } from 'next/navigation';
 import { useUserPosts } from './_hooks/useUserPosts';
 
 const UserProfile = ({ params }: { params: { userId: number } }) => {
-  // TODO: profileがnullの時が内容にローディングとか入れたい
+  // TODO: ローディングとか入れたい
   const { profile, error: gettingProfileError } = useUserProfile(params.userId);
 
   const { posts, error: gettingPostsError } = useUserPosts(params.userId);
 
-  // FIXME: 投稿が無いときどうするか
-  // if (gettingProfileError || gettingPostsError) notFound();
+  if (gettingProfileError || gettingPostsError) notFound();
 
   return (
     <div className='container mx-auto px-4 py-8'>

--- a/app/profile/[userId]/page.tsx
+++ b/app/profile/[userId]/page.tsx
@@ -32,26 +32,24 @@ const UserProfile = ({ params }: { params: { userId: number } }) => {
             </div>
           </div>
         </div>
-        {posts?.length !== 0 &&
-          posts?.map((post: PostType) => {
-            <div className='bg-white shadow-md rounded p-4 mb-4' key={post.id}>
-              <div className='mb-4'>
-                <div className='flex items-center mb-2'>
-                  <img
-                    className='w-10 h-10 rounded-full mr-2'
-                    alt='User Avatar'
-                  />
-                  <div>
-                    <h2 className='font-semibold text-md'>
-                      {post.author.name}
-                    </h2>
-                    <p className='text-gray-500 text-sm'>{post.createdAt}</p>
-                  </div>
+        {posts?.map((post: PostType) => (
+          <div className='bg-white shadow-md rounded p-4 mb-4' key={post.id}>
+            <div className='mb-4'>
+              <div className='flex items-center mb-2'>
+                <img
+                  className='w-10 h-10 rounded-full mr-2'
+                  alt='User Avatar'
+                  src={profile?.imageUrl}
+                />
+                <div>
+                  <h2 className='font-semibold text-md'>{post.author.name}</h2>
+                  <p className='text-gray-500 text-sm'>{post.createdAt}</p>
                 </div>
-                <p className='text-gray-700'>{post.content}</p>
               </div>
-            </div>;
-          })}
+              <p className='text-gray-700'>{post.content}</p>
+            </div>
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/app/profile/[userId]/page.tsx
+++ b/app/profile/[userId]/page.tsx
@@ -6,14 +6,10 @@ import { useUserPosts } from './_hooks/useUserPosts';
 
 const UserProfile = ({ params }: { params: { userId: string } }) => {
   // TODO: ローディングとか入れたい
-  const { profile, error: gettingProfileError } = useUserProfile(
-    Number(params.userId)
-  );
+  const { profile, error: gettingProfileError } = useUserProfile(params.userId);
   if (gettingProfileError) notFound();
 
-  const { posts, error: gettingPostsError } = useUserPosts(
-    Number(params.userId)
-  );
+  const { posts, error: gettingPostsError } = useUserPosts(params.userId);
   if (gettingPostsError) notFound();
 
   return (

--- a/app/profile/[userId]/page.tsx
+++ b/app/profile/[userId]/page.tsx
@@ -4,13 +4,17 @@ import { PostType } from '@/app/types/post';
 import { notFound } from 'next/navigation';
 import { useUserPosts } from './_hooks/useUserPosts';
 
-const UserProfile = ({ params }: { params: { userId: number } }) => {
+const UserProfile = ({ params }: { params: { userId: string } }) => {
   // TODO: ローディングとか入れたい
-  const { profile, error: gettingProfileError } = useUserProfile(params.userId);
+  const { profile, error: gettingProfileError } = useUserProfile(
+    Number(params.userId)
+  );
+  if (gettingProfileError) notFound();
 
-  const { posts, error: gettingPostsError } = useUserPosts(params.userId);
-
-  if (gettingProfileError || gettingPostsError) notFound();
+  const { posts, error: gettingPostsError } = useUserPosts(
+    Number(params.userId)
+  );
+  if (gettingPostsError) notFound();
 
   return (
     <div className='container mx-auto px-4 py-8'>


### PR DESCRIPTION
## 概要
- 表題通り

## 実装詳細
- 任意のユーザーのpostを取得するhookを追加
- 取得したpostsをmapで表示させる
- postとprofile取得時のエラーはnot foundページを表示させる

## 画面
- データがある時
![スクリーンショット 2024-02-07 13 10 57](https://github.com/exchange-wata/next.js14-udemy-sns-client/assets/36654133/3ccfcd2c-5d32-47ef-8653-16ff20ef7f8a)

- 任意のユーザーがそもそもいない時
![スクリーンショット 2024-02-07 13 10 52](https://github.com/exchange-wata/next.js14-udemy-sns-client/assets/36654133/aec4237c-256c-4fb4-86b7-87191cb467e5)
